### PR TITLE
Fix JWT Prefix

### DIFF
--- a/express-api/src/configs/jwt/jwt.ts
+++ b/express-api/src/configs/jwt/jwt.ts
@@ -31,7 +31,7 @@ const jwtConfig = {
   publicKey: fs.readFileSync('jwt_public.pem'),
   privateKey: fs.readFileSync('jwt_private.pem'),
 
-  cookieName: process.env.NODE_ENV !== 'development' ? '__Secure-jwt' : 'jwt',
+  cookieName: 'auth-jwt',
   cookieOptions,
   tokenOptions,
 };


### PR DESCRIPTION
There was a bug where express would not clear the `__Secure-jwt` I *think* in part with the `__Secure` prefix. I have removed that requirement and just named the cookie `auth-jwt` which should fix the issue.