### PR TITLE
Better JWT

### DIFF
--- a/express-api/src/configs/jwt/index.ts
+++ b/express-api/src/configs/jwt/index.ts
@@ -1,2 +1,1 @@
 export { default } from './jwt';
-export * from './jwt';

--- a/express-api/src/configs/jwt/jwt.ts
+++ b/express-api/src/configs/jwt/jwt.ts
@@ -2,12 +2,6 @@ import { CookieOptions } from 'express';
 import fs from 'fs';
 import { SignOptions } from 'jsonwebtoken';
 
-import { User } from '../../models/user';
-
-export interface JWT {
-  user: User;
-}
-
 const hours = 0;
 const minutes = 30;
 const seconds = 0;

--- a/express-api/src/inits/passport/passport.ts
+++ b/express-api/src/inits/passport/passport.ts
@@ -8,7 +8,7 @@ passport.use(new GoogleStrategy(
   googleStrategyOptions,
   (accessToken, refreshToken, profile, done) => {
     findOrCreateUser(profile.displayName, profile.emails![0].value) // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      .then((user) => done(undefined, user))
+      .then((user) => done(undefined, user.toJSON()))
       .catch((e) => done(e));
   },
 ));

--- a/express-api/src/middleware/jwt/jwt.ts
+++ b/express-api/src/middleware/jwt/jwt.ts
@@ -1,17 +1,16 @@
 import { RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
 
-import jwtConfig, { JWT } from '../../configs/jwt';
+import jwtConfig from '../../configs/jwt';
+import { User } from '../../models/user';
 import { findUserByEmail } from '../../services/user';
 
 const updateJWT = (): RequestHandler => async (req, res, next) => {
   if (req.cookies[jwtConfig.cookieName]) {
     try {
-      const { user: decoded } = jwt.verify(req.cookies[jwtConfig.cookieName], jwtConfig.publicKey) as JWT;
+      const user = jwt.verify(req.cookies[jwtConfig.cookieName], jwtConfig.publicKey) as User;
 
-      const user = await findUserByEmail(decoded.email);
-
-      const token = jwt.sign({ user }, jwtConfig.privateKey, jwtConfig.tokenOptions);
+      const token = jwt.sign({ ...(await findUserByEmail(user.email)).toJSON() }, jwtConfig.privateKey, jwtConfig.tokenOptions);
 
       res.cookie(jwtConfig.cookieName, token, jwtConfig.cookieOptions);
     }

--- a/express-api/src/middleware/jwt/jwt.ts
+++ b/express-api/src/middleware/jwt/jwt.ts
@@ -8,9 +8,10 @@ import { findUserByEmail } from '../../services/user';
 const updateJWT = (): RequestHandler => async (req, res, next) => {
   if (req.cookies[jwtConfig.cookieName]) {
     try {
-      const user = jwt.verify(req.cookies[jwtConfig.cookieName], jwtConfig.publicKey) as User;
+      let user = jwt.verify(req.cookies[jwtConfig.cookieName], jwtConfig.publicKey) as User;
+      user = (await findUserByEmail(user.email)).toJSON();
 
-      const token = jwt.sign({ ...(await findUserByEmail(user.email)).toJSON() }, jwtConfig.privateKey, jwtConfig.tokenOptions);
+      const token = jwt.sign({ ...user }, jwtConfig.privateKey, jwtConfig.tokenOptions);
 
       res.cookie(jwtConfig.cookieName, token, jwtConfig.cookieOptions);
     }

--- a/express-api/src/models/user/user.ts
+++ b/express-api/src/models/user/user.ts
@@ -9,10 +9,10 @@ export interface User {
   email: string;
 
   role: 'Admin' | 'Manager' | 'User';
-  teamId?: Types.ObjectId;
+  teamId?: string;
 }
 
-export type UserDocument = User & Document;
+export type UserDocument = Omit<User, 'teamId'> & Document & { teamId?: Types.ObjectId };
 
 export const User = model<UserDocument>('User', new Schema({
   name: { type: String, required: true },

--- a/express-api/src/models/user/user.ts
+++ b/express-api/src/models/user/user.ts
@@ -12,7 +12,7 @@ export interface User {
   teamId?: string;
 }
 
-export type UserDocument = Omit<User, '_id' | 'teamId'> & Document & { _id: Types.ObjectId; teamId?: Types.ObjectId };
+export type UserDocument = Omit<User, 'teamId'> & Document & { teamId?: Types.ObjectId };
 
 export const User = model<UserDocument>('User', new Schema({
   name: { type: String, required: true },

--- a/express-api/src/models/user/user.ts
+++ b/express-api/src/models/user/user.ts
@@ -3,7 +3,7 @@ import {
 } from 'mongoose';
 
 export interface User {
-  _id?: Types.ObjectId;
+  _id?: string;
 
   name: string;
   email: string;

--- a/express-api/src/models/user/user.ts
+++ b/express-api/src/models/user/user.ts
@@ -12,7 +12,7 @@ export interface User {
   teamId?: string;
 }
 
-export type UserDocument = Omit<User, 'teamId'> & Document & { teamId?: Types.ObjectId };
+export type UserDocument = Omit<User, '_id' | 'teamId'> & Document & { _id: Types.ObjectId; teamId?: Types.ObjectId };
 
 export const User = model<UserDocument>('User', new Schema({
   name: { type: String, required: true },

--- a/express-api/src/routes/auth/auth.ts
+++ b/express-api/src/routes/auth/auth.ts
@@ -2,7 +2,8 @@ import { Router } from 'express';
 import jwt from 'jsonwebtoken';
 
 import googleRoutes from './google';
-import jwtConfig, { JWT } from '../../configs/jwt';
+import jwtConfig from '../../configs/jwt';
+import { User } from '../../models/user';
 
 const router = Router();
 
@@ -11,7 +12,7 @@ router.use('/google', googleRoutes);
 router.get('/isLoggedIn', (req, res) => res.status(200).json({
   status: 200,
   isLoggedIn: !!req.cookies[jwtConfig.cookieName],
-  user: req.cookies[jwtConfig.cookieName] && (jwt.decode(req.cookies[jwtConfig.cookieName]) as JWT).user,
+  user: req.cookies[jwtConfig.cookieName] && jwt.decode(req.cookies[jwtConfig.cookieName]) as User,
 }));
 
 router.get('/logout', (req, res) => {

--- a/express-api/src/routes/auth/auth.ts
+++ b/express-api/src/routes/auth/auth.ts
@@ -9,11 +9,16 @@ const router = Router();
 
 router.use('/google', googleRoutes);
 
-router.get('/isLoggedIn', (req, res) => res.status(200).json({
-  status: 200,
-  isLoggedIn: !!req.cookies[jwtConfig.cookieName],
-  user: req.cookies[jwtConfig.cookieName] && jwt.decode(req.cookies[jwtConfig.cookieName]) as User,
-}));
+router.get('/isLoggedIn', (req, res) => {
+  const user = req.cookies[jwtConfig.cookieName] && jwt.decode(req.cookies[jwtConfig.cookieName]) as User;
+
+  return res.status(200).json({
+    status: 200,
+    isLoggedIn: !!user,
+    user,
+    message: user ? 'Logged in' : 'Not logged in',
+  });
+});
 
 router.get('/logout', (req, res) => {
   res.clearCookie(jwtConfig.cookieName);

--- a/express-api/src/routes/auth/google/google.ts
+++ b/express-api/src/routes/auth/google/google.ts
@@ -10,7 +10,7 @@ router.get('/', passport.authenticate('google'));
 
 router.get('/callback', passport.authenticate('google', { session: false }), (req, res) => {
   try {
-    const token = jwt.sign({ user: req.user }, jwtConfig.privateKey, jwtConfig.tokenOptions);
+    const token = jwt.sign({ ...req.user }, jwtConfig.privateKey, jwtConfig.tokenOptions);
 
     res.cookie(jwtConfig.cookieName, token, jwtConfig.cookieOptions);
   }


### PR DESCRIPTION
1. Realized that the User interface `_id?` needed to be string instead of `Types.ObjectId`

1. Improved JWT by making it less complicated. We now send the JSON'd user document through passport and spread the user, removing an unnecessary JWT interface in the process. JWT's used to look like
```js
{
  user: {
    ...
  }
}
```
and are now just 
```js
{
  ...
}
```
This will making doing middleware easier as we are no longer doing some weird intermediate interface, instead we can just says `jwt.decode() as User`.