### PR TITLE
Team Editing

### DIFF
--- a/react-app/src/Routes/Routes.tsx
+++ b/react-app/src/Routes/Routes.tsx
@@ -1,8 +1,12 @@
 import React, { lazy, Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import AdminRoute from './protected/Admin';
+import ManagerRoute from './protected/Manager';
+
 const Home = lazy(() => import('../pages/Home'));
 const Team = lazy(() => import('../pages/Team'));
+const TeamEdit = lazy(() => import('../pages/TeamEdit'));
 const Teams = lazy(() => import('../pages/Teams'));
 const NotFound = lazy(() => import('../pages/NotFound'));
 
@@ -10,17 +14,12 @@ const Routes: React.FC = () => (
   <main style={{ overflowX: 'hidden' }}>
     <Suspense fallback={<div>Loading...</div>}>
       <Switch>
-        <Route exact path="/">
-          <Home />
-        </Route>
+        <Route exact path="/"><Home /></Route>
 
-        <Route exact path="/teams">
-          <Teams />
-        </Route>
-
-        <Route exact path="/teams/:identifierOrId">
-          <Team />
-        </Route>
+        <Route exact path="/teams"><Teams /></Route>
+        <AdminRoute exact path="/teams/createTeam"><TeamEdit /></AdminRoute>
+        <Route exact path="/teams/:identifierOrId"><Team /></Route>
+        <ManagerRoute exact path="/teams/:identifierOrId/edit"><TeamEdit /></ManagerRoute>
 
         <Route>
           <NotFound />

--- a/react-app/src/components/forms/Team/Division/DivisionForm.tsx
+++ b/react-app/src/components/forms/Team/Division/DivisionForm.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
+import ArrowLeftBoldIcon from 'mdi-material-ui/ArrowLeftBold';
+import ArrowRightBoldIcon from 'mdi-material-ui/ArrowRightBold';
+import DeleteIcon from 'mdi-material-ui/Delete';
+
+import PlayerForm from './Player';
+import PlayerCard from '../../../cards/Player';
+import Division from '../../../../models/team/division';
+import { DivisionActions } from '../../../../utils/team';
+
+const useStyles = makeStyles((theme) => createStyles({
+  buttonGroup: {
+    marginTop: theme.spacing(1),
+  },
+  card: {
+    textAlign: 'center',
+  },
+}));
+
+type Props = {
+  division: Division,
+  dispatch: React.Dispatch<DivisionActions>
+};
+const DivisionForm: React.FC<Props> = ({ division, dispatch }) => {
+  const classes = useStyles();
+
+  return (
+    <Grid container direction="column" alignItems="center">
+      <Grid item>
+        <TextField value={division.name || ''} label="Division Name" variant="outlined" margin="normal" onChange={(e) => dispatch({ type: 'DIVISION_SET_NAME', division, name: e.target.value })} />
+      </Grid>
+      <Grid item container justify="center" spacing={5}>
+        {division.players?.map((player, index, playerArr) => (
+          <Grid key={player._id} item>
+            <PlayerCard player={player}>
+              <PlayerForm division={division} player={player} dispatch={dispatch} />
+              <ButtonGroup fullWidth className={classes.buttonGroup}>
+                <Button color="secondary" onClick={() => dispatch({ type: 'DIVISION_PLAYER_REMOVE', division, player })}><DeleteIcon /></Button>
+                <Button color="primary" disabled={index === 0} onClick={() => dispatch({ type: 'DIVISION_PLAYER_UP', division, player })}><ArrowLeftBoldIcon /></Button>
+                <Button color="primary" disabled={index === playerArr.length - 1} onClick={() => dispatch({ type: 'DIVISION_PLAYER_DOWN', division, player })}><ArrowRightBoldIcon /></Button>
+              </ButtonGroup>
+            </PlayerCard>
+          </Grid>
+        ))}
+        <Grid item className={classes.card}>
+          <PlayerCard>
+            <Button size="large" variant="outlined" color="primary" onClick={() => dispatch({ type: 'DIVISION_PLAYER_ADD', division })}>Add Player</Button>
+          </PlayerCard>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default DivisionForm;

--- a/react-app/src/components/forms/Team/Division/Player/PlayerForm.tsx
+++ b/react-app/src/components/forms/Team/Division/Player/PlayerForm.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import { makeStyles } from '@material-ui/core/styles';
+
+import Division from '../../../../../models/team/division';
+import Player from '../../../../../models/team/division/player';
+import { PlayerActions } from '../../../../../utils/team';
+
+const useStyles = makeStyles({
+  playerInput: {
+    display: 'block',
+  },
+});
+
+type Props = {
+  division: Division
+  player: Player,
+  dispatch: React.Dispatch<PlayerActions>
+};
+const PlayerForm: React.FC<Props> = ({ division, player, dispatch }) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <TextField
+        required
+        label="Player Userame"
+        value={player.username}
+        error={!player.username}
+        helperText={!player.username && 'Player Username Required'}
+        variant="outlined"
+        margin="normal"
+        onChange={(e) => dispatch({
+          type: 'PLAYER_SET_USERNAME', division, player, username: e.target.value,
+        })}
+        fullWidth
+        className={classes.playerInput}
+      />
+      <TextField
+        required
+        label="Player Userame"
+        value={player.role}
+        error={!player.role}
+        helperText={!player.role && 'Player Role Required'}
+        variant="outlined"
+        margin="normal"
+        onChange={(e) => dispatch({
+          type: 'PLAYER_SET_ROLE', division, player, role: e.target.value,
+        })}
+        fullWidth
+        className={classes.playerInput}
+      />
+      <TextField
+        label="Player Image URL"
+        value={player.imageUrl || ''}
+        variant="outlined"
+        margin="normal"
+        onChange={(e) => dispatch({
+          type: 'PLAYER_SET_IMAGE_URL', division, player, imageUrl: e.target.value,
+        })}
+        fullWidth
+        className={classes.playerInput}
+      />
+    </>
+  );
+};
+
+export default PlayerForm;

--- a/react-app/src/components/forms/Team/Division/Player/index.ts
+++ b/react-app/src/components/forms/Team/Division/Player/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PlayerForm';

--- a/react-app/src/components/forms/Team/Division/index.ts
+++ b/react-app/src/components/forms/Team/Division/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DivisionForm';

--- a/react-app/src/components/forms/Team/TeamForm.tsx
+++ b/react-app/src/components/forms/Team/TeamForm.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import { makeStyles } from '@material-ui/core/styles';
+
+import ArrowDownBoldIcon from 'mdi-material-ui/ArrowDownBold';
+import ArrowUpBoldIcon from 'mdi-material-ui/ArrowUpBold';
+import DeleteIcon from 'mdi-material-ui/Delete';
+
+import DivisionForm from './Division';
+import TeamCard from '../../cards/Team';
+import Team from '../../../models/team';
+import { TeamActions } from '../../../utils/team';
+
+const useStyles = makeStyles({
+  teamInputs: {
+    paddingBottom: '0 !important',
+  },
+  teamInput: {
+    display: 'block',
+  },
+  card: {
+    textAlign: 'center',
+  },
+});
+
+type Props = {
+  team: Team,
+  dispatch: React.Dispatch<TeamActions>,
+};
+const TeamForm: React.FC<Props> = ({ team, dispatch }) => {
+  const classes = useStyles();
+
+  return (
+    <Grid container direction="column" alignItems="center" spacing={5}>
+      <Grid item className={classes.teamInputs}>
+        <TextField
+          required
+          label="Team Name"
+          value={team.name}
+          error={!team.name}
+          helperText={!team.name && 'Team Name Required'}
+          variant="outlined"
+          margin="normal"
+          onChange={(e) => dispatch({ type: 'TEAM_SET_NAME', name: e.target.value })}
+          className={classes.teamInput}
+        />
+        <TextField
+          required
+          label="Team Identifier"
+          value={team.identifier}
+          error={!team.identifier}
+          helperText={!team.identifier && 'Team Identifier Reqired'}
+          variant="outlined"
+          margin="normal"
+          onChange={(e) => dispatch({ type: 'TEAM_SET_IDENTIFIER', identifier: e.target.value })}
+          className={classes.teamInput}
+        />
+      </Grid>
+      {team.divisions?.map((division, index, divisionArr) => (
+        <React.Fragment key={division._id}>
+          <Grid item>
+            <DivisionForm division={division} dispatch={dispatch} />
+          </Grid>
+          <Grid item>
+            <ButtonGroup size="large">
+              <Button variant="contained" color="secondary" onClick={() => dispatch({ type: 'TEAM_DIVISION_REMOVE', division })}><DeleteIcon /></Button>
+              <Button variant="contained" color="primary" disabled={index === 0} onClick={() => dispatch({ type: 'TEAM_DIVISION_UP', division })}><ArrowUpBoldIcon /></Button>
+              <Button variant="contained" color="primary" disabled={index === divisionArr.length - 1} onClick={() => dispatch({ type: 'TEAM_DIVISION_DOWN', division })}><ArrowDownBoldIcon /></Button>
+            </ButtonGroup>
+          </Grid>
+        </React.Fragment>
+      ))}
+      <Grid item className={classes.card}>
+        <TeamCard>
+          <Button variant="outlined" size="large" color="primary" onClick={() => dispatch({ type: 'TEAM_DIVISION_ADD' })}>Add Division</Button>
+        </TeamCard>
+      </Grid>
+    </Grid>
+  );
+};
+export default TeamForm;

--- a/react-app/src/components/forms/Team/index.ts
+++ b/react-app/src/components/forms/Team/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TeamForm';

--- a/react-app/src/pages/TeamEdit/TeamEdit.tsx
+++ b/react-app/src/pages/TeamEdit/TeamEdit.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useHistory, useParams } from 'react-router-dom';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+
+import Alert from '@material-ui/lab/Alert';
+
+import TeamForm from '../../components/forms/Team';
+import { useTeam } from '../../utils/team';
+
+const useStyles = makeStyles((theme) => createStyles({
+  top: {
+    marginTop: theme.spacing(3),
+  },
+}));
+
+type Params = {
+  identifierOrId: string | undefined
+};
+const TeamEdit: React.FC = () => {
+  const classes = useStyles();
+
+  const history = useHistory();
+  const { identifierOrId } = useParams<Params>();
+
+  const { team, teamDispatch, canDelete } = useTeam(identifierOrId);
+  const [error, setError] = useState<string>();
+
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const newTeam = !identifierOrId;
+
+  const handleSumbit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const form = event.currentTarget;
+
+    if (form.checkValidity()) {
+      if (newTeam) {
+        axios.post('/api/teams/', team)
+          .then(() => history.push(`/teams/${team.identifier}`))
+          .catch((e) => setError(e.response.data.message || e.response.statusText));
+      }
+      else {
+        axios.put(`/api/teams/${team._id}`, team)
+          .then(() => history.push(`/teams/${team.identifier}`))
+          .catch((e) => setError(e.response.data.message || e.response.statusText));
+      }
+    }
+  };
+
+  const handleDelete = () => {
+    if (!newTeam && canDelete && confirmDelete) {
+      axios.delete(`/api/teams/${team._id}`)
+        .then(() => history.replace('/teams'))
+        .catch((e) => setError(e.response.data.message || e.response.statusText));
+    }
+    else {
+      setConfirmDelete(true);
+    }
+  };
+
+  return (
+    <>
+      {error && <Alert severity="error">{error}</Alert>}
+      <form noValidate autoComplete="off" onSubmit={handleSumbit}>
+        <Grid container direction="column" alignItems="center" spacing={5}>
+          <Grid item className={classes.top}>
+            <Button type="submit" size="large" variant="contained" color="primary">Save Team</Button>
+          </Grid>
+          <Grid item>
+            <TeamForm team={team} dispatch={teamDispatch} />
+          </Grid>
+          {!newTeam && canDelete && (
+            <Grid item>
+              <Button size="large" variant="contained" color="secondary" onClick={handleDelete}>{confirmDelete ? 'Confirm Delete' : 'Delete Team'}</Button>
+            </Grid>
+          )}
+        </Grid>
+      </form>
+    </>
+  );
+};
+
+export default TeamEdit;

--- a/react-app/src/pages/TeamEdit/index.ts
+++ b/react-app/src/pages/TeamEdit/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TeamEdit';

--- a/react-app/src/utils/team/actions.ts
+++ b/react-app/src/utils/team/actions.ts
@@ -1,0 +1,43 @@
+import Team from '../../models/team';
+import Division from '../../models/team/division';
+import League from '../../models/team/division/league';
+import Player from '../../models/team/division/player';
+
+export type TeamActions =
+  | { type: 'SET_TEAM', team: Team }
+
+  | { type: 'TEAM_SET_NAME', name: string }
+  | { type: 'TEAM_SET_IDENTIFIER', identifier: string }
+
+  | { type: 'TEAM_DIVISION_ADD' }
+  | { type: 'TEAM_DIVISION_REMOVE', division: Division }
+  | { type: 'TEAM_DIVISION_UP', division: Division }
+  | { type: 'TEAM_DIVISION_DOWN', division: Division }
+
+  | DivisionActions;
+
+export type DivisionActions =
+  | { type: 'DIVISION_SET_NAME', division: Division, name: string }
+
+  | { type: 'DIVISION_LEAGUE_ADD', division: Division }
+  | { type: 'DIVISION_LEAGUE_REMOVE', division: Division, league: League }
+  | { type: 'DIVISION_LEAGUE_UP', division: Division, league: League }
+  | { type: 'DIVISION_LEAGUE_DOWN', division: Division, league: League }
+
+  | { type: 'DIVISION_PLAYER_ADD', division: Division }
+  | { type: 'DIVISION_PLAYER_REMOVE', division: Division, player: Player }
+  | { type: 'DIVISION_PLAYER_UP', division: Division, player: Player }
+  | { type: 'DIVISION_PLAYER_DOWN', division: Division, player: Player }
+
+  | LeagueActions
+  | PlayerActions;
+
+export type LeagueActions =
+  | { type: 'LEAGUE_SET_NAME', division: Division, league: League, name: string }
+  | { type: 'LEAGUE_SET_URL', division: Division, league: League, url: string }
+  | { type: 'LEAGUE_SET_IMAGE_URL', division: Division, league: League, imageUrl: string };
+
+export type PlayerActions =
+  | { type: 'PLAYER_SET_USERNAME', division: Division, player: Player, username: string }
+  | { type: 'PLAYER_SET_ROLE', division: Division, player: Player, role: string }
+  | { type: 'PLAYER_SET_IMAGE_URL', division: Division, player: Player, imageUrl: string };

--- a/react-app/src/utils/team/index.ts
+++ b/react-app/src/utils/team/index.ts
@@ -1,2 +1,5 @@
 export { default as useTeam } from './useTeam';
 export { default as useTeams } from './useTeams';
+export type {
+  TeamActions, DivisionActions, LeagueActions, PlayerActions,
+} from './actions';

--- a/react-app/src/utils/team/teamReducer.ts
+++ b/react-app/src/utils/team/teamReducer.ts
@@ -1,0 +1,186 @@
+import { Reducer } from 'react';
+
+import {
+  TeamActions, DivisionActions, LeagueActions, PlayerActions,
+} from './actions';
+import Team from '../../models/team';
+import Division from '../../models/team/division';
+import League from '../../models/team/division/league';
+import Player from '../../models/team/division/player';
+
+const playerReducer: Reducer<Player, PlayerActions> = (prevPlayer, action) => {
+  switch (action.type) {
+    case 'PLAYER_SET_USERNAME':
+      return { ...prevPlayer, username: action.username };
+    case 'PLAYER_SET_ROLE':
+      return { ...prevPlayer, role: action.role };
+    case 'PLAYER_SET_IMAGE_URL':
+      return { ...prevPlayer, imageUrl: action.imageUrl ? action.imageUrl : undefined };
+    default:
+      return prevPlayer;
+  }
+};
+
+const leagueReducer: Reducer<League, LeagueActions> = (prevLeague, action) => {
+  switch (action.type) {
+    case 'LEAGUE_SET_NAME':
+      return { ...prevLeague, name: action.name };
+    case 'LEAGUE_SET_URL':
+      return { ...prevLeague, url: action.url };
+    case 'LEAGUE_SET_IMAGE_URL':
+      return { ...prevLeague, imageUrl: action.imageUrl ? action.imageUrl : undefined };
+
+    default:
+      return prevLeague;
+  }
+};
+
+const divisionReducer: Reducer<Division, DivisionActions> = (prevDivision, action) => {
+  switch (action.type) {
+    case 'DIVISION_SET_NAME':
+      return { ...prevDivision, name: action.name ? action.name : undefined };
+
+    case 'DIVISION_LEAGUE_ADD':
+      return { ...prevDivision, leagues: prevDivision.leagues ? [...prevDivision.leagues, new League()] : [new League()] };
+    case 'DIVISION_LEAGUE_REMOVE':
+      return { ...prevDivision, leagues: prevDivision.leagues?.filter((league) => league !== action.league) };
+    case 'DIVISION_LEAGUE_UP':
+      if (prevDivision.leagues) {
+        const index = prevDivision.leagues.indexOf(action.league);
+
+        if (index !== 0 && index !== -1) {
+          const leaguesCopy = [...prevDivision.leagues];
+
+          [leaguesCopy[index - 1], leaguesCopy[index]] = [leaguesCopy[index], leaguesCopy[index - 1]];
+
+          return { ...prevDivision, leagues: leaguesCopy };
+        }
+      }
+      return prevDivision;
+    case 'DIVISION_LEAGUE_DOWN':
+      if (prevDivision.leagues) {
+        const index = prevDivision.leagues.indexOf(action.league);
+
+        if (index !== prevDivision.leagues.length - 1 && index !== -1) {
+          const leaguesCopy = [...prevDivision.leagues];
+
+          [leaguesCopy[index], leaguesCopy[index + 1]] = [leaguesCopy[index + 1], leaguesCopy[index]];
+
+          return { ...prevDivision, leagues: leaguesCopy };
+        }
+      }
+      return prevDivision;
+
+    case 'DIVISION_PLAYER_ADD':
+      return { ...prevDivision, players: prevDivision.players ? [...prevDivision.players, new Player()] : [new Player()] };
+    case 'DIVISION_PLAYER_REMOVE':
+      return { ...prevDivision, players: prevDivision.players?.filter((player) => player !== action.player) };
+    case 'DIVISION_PLAYER_UP':
+      if (prevDivision.players) {
+        const index = prevDivision.players.indexOf(action.player);
+
+        if (index !== 0 && index !== -1) {
+          const playersCopy = [...prevDivision.players];
+
+          [playersCopy[index - 1], playersCopy[index]] = [playersCopy[index], playersCopy[index - 1]];
+
+          return { ...prevDivision, players: playersCopy };
+        }
+      }
+      return prevDivision;
+    case 'DIVISION_PLAYER_DOWN':
+      if (prevDivision.players) {
+        const index = prevDivision.players.indexOf(action.player);
+
+        if (index !== prevDivision.players.length - 1 && index !== -1) {
+          const playersCopy = [...prevDivision.players];
+
+          [playersCopy[index], playersCopy[index + 1]] = [playersCopy[index + 1], playersCopy[index]];
+
+          return { ...prevDivision, players: playersCopy };
+        }
+      }
+      return prevDivision;
+
+    case 'LEAGUE_SET_NAME':
+    case 'LEAGUE_SET_URL':
+    case 'LEAGUE_SET_IMAGE_URL':
+      return { ...prevDivision, leagues: prevDivision.leagues?.map((league) => (league === action.league ? leagueReducer(league, action) : league)) };
+
+    case 'PLAYER_SET_USERNAME':
+    case 'PLAYER_SET_ROLE':
+    case 'PLAYER_SET_IMAGE_URL':
+      return { ...prevDivision, players: prevDivision.players?.map((player) => (player === action.player ? playerReducer(player, action) : player)) };
+
+    default:
+      return prevDivision;
+  }
+};
+
+const teamReducer: Reducer<Team, TeamActions> = (prevTeam, action) => {
+  switch (action.type) {
+    case 'SET_TEAM':
+      return action.team;
+
+    case 'TEAM_SET_NAME':
+      return { ...prevTeam, name: action.name };
+    case 'TEAM_SET_IDENTIFIER':
+      return { ...prevTeam, identifier: action.identifier.toLowerCase() };
+
+    case 'TEAM_DIVISION_ADD':
+      return { ...prevTeam, divisions: prevTeam.divisions ? [...prevTeam.divisions, new Division()] : [new Division()] };
+    case 'TEAM_DIVISION_REMOVE':
+      return { ...prevTeam, divisions: prevTeam.divisions?.filter((division) => division !== action.division) };
+    case 'TEAM_DIVISION_UP':
+      if (prevTeam.divisions) {
+        const index = prevTeam.divisions.indexOf(action.division);
+
+        if (index !== 0 && index !== -1) {
+          const divisionsCopy = [...prevTeam.divisions];
+
+          [divisionsCopy[index - 1], divisionsCopy[index]] = [divisionsCopy[index], divisionsCopy[index - 1]];
+
+          return { ...prevTeam, divisions: divisionsCopy };
+        }
+      }
+      return prevTeam;
+
+    case 'TEAM_DIVISION_DOWN':
+      if (prevTeam.divisions) {
+        const index = prevTeam.divisions.indexOf(action.division);
+
+        if (index !== prevTeam.divisions.length - 1 && index !== -1) {
+          const divisionsCopy = [...prevTeam.divisions];
+
+          [divisionsCopy[index], divisionsCopy[index + 1]] = [divisionsCopy[index + 1], divisionsCopy[index]];
+
+          return { ...prevTeam, divisions: divisionsCopy };
+        }
+      }
+      return prevTeam;
+
+    case 'DIVISION_SET_NAME':
+    case 'DIVISION_PLAYER_ADD':
+    case 'DIVISION_PLAYER_REMOVE':
+    case 'DIVISION_PLAYER_UP':
+    case 'DIVISION_PLAYER_DOWN':
+    case 'DIVISION_LEAGUE_ADD':
+    case 'DIVISION_LEAGUE_REMOVE':
+    case 'DIVISION_LEAGUE_UP':
+    case 'DIVISION_LEAGUE_DOWN':
+    // fallthrough
+    case 'LEAGUE_SET_NAME':
+    case 'LEAGUE_SET_URL':
+    case 'LEAGUE_SET_IMAGE_URL':
+    // fallthrough
+    case 'PLAYER_SET_USERNAME':
+    case 'PLAYER_SET_ROLE':
+    case 'PLAYER_SET_IMAGE_URL':
+      return { ...prevTeam, divisions: prevTeam.divisions?.map((division) => (division === action.division ? divisionReducer(division, action) : division)) };
+
+    default:
+      return prevTeam;
+  }
+};
+
+export default teamReducer;

--- a/react-app/src/utils/team/useTeam.ts
+++ b/react-app/src/utils/team/useTeam.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 import axios from 'axios';
 
+import teamReducer from './teamReducer';
 import Team from '../../models/team';
 
 interface TeamRes {
@@ -12,7 +13,7 @@ interface TeamRes {
 }
 
 const useTeam = (identifierOrId?: string) => {
-  const [team, setTeam] = useState(new Team());
+  const [team, teamDispatch] = useReducer(teamReducer, new Team());
   const [error, setError] = useState<string>();
 
   const [canDelete, setCanDelete] = useState(false);
@@ -22,7 +23,7 @@ const useTeam = (identifierOrId?: string) => {
     if (identifierOrId) {
       axios.get<TeamRes>(`/api/teams/${identifierOrId}`)
         .then(({ data }) => {
-          setTeam(data.team);
+          teamDispatch({ type: 'SET_TEAM', team: data.team });
 
           setCanDelete(data.canDelete);
           setCanEdit(data.canEdit);
@@ -32,7 +33,7 @@ const useTeam = (identifierOrId?: string) => {
   }, [identifierOrId]);
 
   return {
-    team, error, canDelete, canEdit,
+    team, error, teamDispatch, canDelete, canEdit,
   };
 };
 


### PR DESCRIPTION
Team editing has made it's return! Just looks nice and has the same functionality from the old site. 

Custom reducer that just works, don't ask. It just does. I spent 4 hours on it. Don't touch it please.

Creating teams is only for Admins, editing teams is for managers. Custom error messages shown if you try to edit a team that isn't yours. 

League Editing isn't available quite yet, still talking with production director and @zjc9022 on how we want to design those. I was thinking maybe something like a [chip](https://material-ui.com/components/chips/)? Oh well, out of scope for this PR.