### PR TITLE
Fix Twitter Widgets

### DIFF
--- a/react-app/src/components/twitter/Timeline/TwitterTimeline.tsx
+++ b/react-app/src/components/twitter/Timeline/TwitterTimeline.tsx
@@ -56,17 +56,19 @@ const TwitterTimeline: React.FC<Props> = ({
 
   useEffect(() => {
     if (twitterTimeline.current) {
-      window.twttr.widgets.createTimeline(
-        rest,
-        twitterTimeline.current,
-        {
-          chrome: `${noHeader ? 'noheader ' : ''}${noFooter ? 'nofooter ' : ''}${noBorders ? 'noborders ' : ''}${transparent ? 'transparent ' : ''}${noScrollbar ? 'noscrollbar ' : ''}`.trim(),
-          height: height || getCalculatedHeight() || 600,
-          ...tweetLimit && (1 <= tweetLimit && tweetLimit <= 20) && { tweetLimit },
-          ...borderColor && { borderColor },
-          ...ariaPolite && { ariaPolite },
-        },
-      );
+      window.twttr.ready((twttr) => {
+        twttr.widgets.createTimeline(
+          rest,
+          twitterTimeline.current,
+          {
+            chrome: `${noHeader ? 'noheader ' : ''}${noFooter ? 'nofooter ' : ''}${noBorders ? 'noborders ' : ''}${transparent ? 'transparent ' : ''}${noScrollbar ? 'noscrollbar ' : ''}`.trim(),
+            height: height || getCalculatedHeight() || 600,
+            ...tweetLimit && (1 <= tweetLimit && tweetLimit <= 20) && { tweetLimit },
+            ...borderColor && { borderColor },
+            ...ariaPolite && { ariaPolite },
+          },
+        ).catch(() => { });
+      });
     }
   }, [noHeader, noFooter, noBorders, transparent, noScrollbar, height, tweetLimit, borderColor, ariaPolite, rest]);
 

--- a/react-app/src/components/twitter/Timeline/index.ts
+++ b/react-app/src/components/twitter/Timeline/index.ts
@@ -1,16 +1,20 @@
+type Twttr = {
+  widgets: {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    // TODO: actually type props
+    createShareButton: (...props: any) => Promise<HTMLElement>;
+    createFollowButton: (...props: any) => Promise<HTMLElement>;
+    createHashtagButton: (...props: any) => Promise<HTMLElement>;
+    createMentionButton: (...props: any) => Promise<HTMLElement>;
+    createTweet: (...props: any) => Promise<HTMLElement>;
+    createTimeline: (...props: any) => Promise<HTMLElement>;
+  }
+};
+
 declare global {
   interface Window {
     twttr: {
-      widgets: {
-        /* eslint-disable @typescript-eslint/no-explicit-any */
-        // TODO: actually type these
-        createShareButton: (...props: any) => void;
-        createFollowButton: (...props: any) => void;
-        createHashtagButton: (...props: any) => void;
-        createMentionButton: (...props: any) => void;
-        createTweet: (...props: any) => void;
-        createTimeline: (...props: any) => void;
-      }
+      ready: (callbackfn: (twttr: Twttr) => void) => void
     }
   }
 }


### PR DESCRIPTION
There is an issue with FireFox's content tracking where the twitter widget.js file will not be loaded and therefore breaks our entire site on load.

This actually led me down a large rabbit hole that allowed me to fix some issues with our code entirely:
1. Typing for `window.twttr.ready` and nothing else. This ensures that when we use it TS will yell at us for not using the async queue AND makes sure that we only load things when the widgets src has loaded.
2. Make the `TwitterTimeline` component *use* `window.twttr.ready` to load

I still need to do the typings for all of the widget create functions. These allow us to maybe do cool things with profiles / teams later ;) ~~@zjc9022~~