### PR TITLE
Profile Photos

### DIFF
--- a/express-api/src/models/profile/profile.ts
+++ b/express-api/src/models/profile/profile.ts
@@ -8,6 +8,7 @@ export interface Profile {
 
   name?: string;
   bio?: string;
+  imageUrl?: string;
 
   facebookUrl?: string;
   twitterUrl?: string;
@@ -24,6 +25,7 @@ export type ProfileDocument = Profile & Document;
 export const Profile = model<ProfileDocument>('Profile', new Schema<Profile>({
   name: { type: String, maxlength: 32 },
   bio: { type: String, maxlength: 160 },
+  imageUrl: String,
 
   facebookUrl: String,
   twitterUrl: String,
@@ -40,6 +42,7 @@ export const ProfileJoi = Joi.object().keys({
 
   name: Joi.string().max(32),
   bio: Joi.string().max(160),
+  imageUrl: Joi.string().regex(/https:\/\/hooli-drive\.sfo2\.digitaloceanspaces\.com\/website\/public\/members\/.+/),
 
   facebookUrl: Joi.string().uri(),
   twitterUrl: Joi.string().uri(),

--- a/express-api/src/models/profile/profile.ts
+++ b/express-api/src/models/profile/profile.ts
@@ -42,7 +42,7 @@ export const ProfileJoi = Joi.object().keys({
 
   name: Joi.string().max(32),
   bio: Joi.string().max(160),
-  imageUrl: Joi.string().regex(/https:\/\/hooli-drive\.sfo2\.digitaloceanspaces\.com\/website\/public\/members\/.+/),
+  imageUrl: Joi.string().regex(/https:\/\/hooli-drive\.sfo2\.digitaloceanspaces\.com\/website\/public\/members\/\S+/),
 
   facebookUrl: Joi.string().uri(),
   twitterUrl: Joi.string().uri(),

--- a/express-api/src/models/team/division/member/member.ts
+++ b/express-api/src/models/team/division/member/member.ts
@@ -1,6 +1,8 @@
 import Joi from '@hapi/joi';
 import { Schema } from 'mongoose';
 
+import { ProfileJoi } from '../../../profile';
+
 export interface Member {
   _id?: string;
 
@@ -11,13 +13,22 @@ export interface Member {
   imageUrl?: string;
 }
 
-export const Member = new Schema<Member>({
+const Member = new Schema<Member>({
   username: { type: String, required: true },
   role: { type: String, required: true },
   profileId: { type: Schema.Types.ObjectId, ref: 'Profile' },
+  // profile: Profile, virtaul,
 
   imageUrl: String,
+}, { toJSON: { virtuals: true }, id: false });
+Member.virtual('profile', {
+  ref: 'Profile',
+  localField: 'profileId',
+  foreignField: '_id',
+  justOne: true,
 });
+
+export { Member };
 
 export const MemberJoi = Joi.object().keys({
   _id: Joi.string().regex(/^[a-f\d]{24}$/i),
@@ -25,6 +36,7 @@ export const MemberJoi = Joi.object().keys({
   username: Joi.string().required(),
   role: Joi.string().required(),
   profileId: Joi.string().regex(/^[a-f\d]{24}$/i),
+  profile: ProfileJoi.allow(null), // virtual
 
   imageUrl: Joi.string().uri(),
 });

--- a/express-api/src/services/team/team.ts
+++ b/express-api/src/services/team/team.ts
@@ -14,7 +14,7 @@ export const createTeam = async (team: Team) => {
 /* Read */
 export const findTeams = async () => {
   try {
-    return await Team.find().sort('name').populate('divisions.members.profile', 'imageUrl');
+    return await Team.find().sort('name').populate('divisions.members.profile', 'name imageUrl');
   }
   catch (e) {
     console.error(e);
@@ -25,7 +25,7 @@ export const findTeamByIdentifierOrId = async (identifierOrId: string) => {
   let team: TeamDocument | null;
 
   try {
-    team = await Team.findOne({ identifier: identifierOrId }).populate('divisions.members.profile', 'imageUrl') || await Team.findById(identifierOrId).populate('divisions.members.profile', 'imageUrl');
+    team = await Team.findOne({ identifier: identifierOrId }).populate('divisions.members.profile', 'name imageUrl') || await Team.findById(identifierOrId).populate('divisions.members.profile', 'name imageUrl');
   }
   catch (e) {
     console.error(e);

--- a/express-api/src/services/team/team.ts
+++ b/express-api/src/services/team/team.ts
@@ -14,7 +14,7 @@ export const createTeam = async (team: Team) => {
 /* Read */
 export const findTeams = async () => {
   try {
-    return await Team.find().sort('name');
+    return await Team.find().sort('name').populate('divisions.members.profile', 'imageUrl');
   }
   catch (e) {
     console.error(e);
@@ -25,7 +25,7 @@ export const findTeamByIdentifierOrId = async (identifierOrId: string) => {
   let team: TeamDocument | null;
 
   try {
-    team = await Team.findOne({ identifier: identifierOrId }) || await Team.findById(identifierOrId);
+    team = await Team.findOne({ identifier: identifierOrId }).populate('divisions.members.profile', 'imageUrl') || await Team.findById(identifierOrId).populate('divisions.members.profile', 'imageUrl');
   }
   catch (e) {
     console.error(e);

--- a/react-app/src/components/cards/Member/MemberCard.tsx
+++ b/react-app/src/components/cards/Member/MemberCard.tsx
@@ -29,7 +29,7 @@ const MemberCard: React.FC<Props> = ({ member, children }) => {
 
   return (
     <Card raised className={classes.card}>
-      <CardMedia component="img" src={member?.imageUrl || Member_No_Photo} alt={member?.imageUrl ? `${member.username}'s Photo` : 'No Member Photo'} onError={onError} />
+      <CardMedia component="img" src={member?.imageUrl || member?.profile?.imageUrl || Member_No_Photo} alt={(member?.imageUrl && `${member.username}'s Photo`) || (member?.profile?.imageUrl && `${member.profile.name || member.profile._id}'s Photo`) || 'No Member Photo'} onError={onError} />
       <CardContent>
         {children || (member && (
           <>

--- a/react-app/src/components/cards/Profile/ProfileCard.tsx
+++ b/react-app/src/components/cards/Profile/ProfileCard.tsx
@@ -36,7 +36,7 @@ const ProfileCard: React.FC<Props> = ({ profile, children }) => {
 
   return (
     <Card raised className={classes.card}>
-      <CardMedia component="img" src={Member_No_Photo} onError={onError} />
+      <CardMedia component="img" src={profile?.imageUrl || Member_No_Photo} alt={profile?.imageUrl ? `${profile.name || profile._id}'s Photo` : 'No Member Photo'} onError={onError} />
       <CardContent>
         {children || (profile && (
           <>

--- a/react-app/src/components/forms/Profile/ProfileForm.tsx
+++ b/react-app/src/components/forms/Profile/ProfileForm.tsx
@@ -51,7 +51,7 @@ const ProfileForm: React.FC<Props> = ({ profile, dispatch }) => {
     <>
       <Grid container justify="center" alignItems="center" spacing={3}>
         <Grid item>
-          <ProfileCard>
+          <ProfileCard profile={profile}>
             <TextField
               label="Name"
               value={profile.name || ''}
@@ -70,6 +70,17 @@ const ProfileForm: React.FC<Props> = ({ profile, dispatch }) => {
               variant="outlined"
               margin="normal"
               onChange={(e) => dispatch({ type: 'PROFILE_SET_BIO', bio: e.target.value })}
+              fullWidth
+              className={classes.profileInput}
+            />
+            <TextField
+              label="Image URL"
+              value={profile.imageUrl || ''}
+              error={!!profile.imageUrl && !/https:\/\/hooli-drive\.sfo2\.digitaloceanspaces\.com\/website\/public\/members\/\S+/.exec(profile.imageUrl)}
+              helperText={!!profile.imageUrl && !/https:\/\/hooli-drive\.sfo2\.digitaloceanspaces\.com\/website\/public\/members\/\S+/.exec(profile.imageUrl) && "Image Must Be From RIT Esports's CDN"}
+              variant="outlined"
+              margin="normal"
+              onChange={(e) => dispatch({ type: 'PROFILE_SET_IMAGE_URL', imageUrl: e.target.value })}
               fullWidth
               className={classes.profileInput}
             />

--- a/react-app/src/models/profile/profile.ts
+++ b/react-app/src/models/profile/profile.ts
@@ -7,6 +7,7 @@ export default class Profile {
 
   name?: string;
   bio?: string;
+  imageUrl?: string;
 
   facebookUrl?: string;
   twitterUrl?: string;

--- a/react-app/src/models/team/division/member/member.ts
+++ b/react-app/src/models/team/division/member/member.ts
@@ -7,6 +7,7 @@ export default class Member {
   role = '';
 
   profileId?: string;
+  profile: { _id: string, imageUrl?: string } | null = null;
 
   imageUrl?: string;
 }

--- a/react-app/src/models/team/division/member/member.ts
+++ b/react-app/src/models/team/division/member/member.ts
@@ -7,7 +7,7 @@ export default class Member {
   role = '';
 
   profileId?: string;
-  profile: { _id: string, imageUrl?: string } | null = null;
+  profile: { _id: string, name?: string, imageUrl?: string } | null = null;
 
   imageUrl?: string;
 }

--- a/react-app/src/utils/profile/actions.ts
+++ b/react-app/src/utils/profile/actions.ts
@@ -6,6 +6,7 @@ export type ProfileActions =
 
   | { type: 'PROFILE_SET_NAME', name: string }
   | { type: 'PROFILE_SET_BIO', bio: string }
+  | { type: 'PROFILE_SET_IMAGE_URL', imageUrl: string }
 
   | { type: 'PROFILE_SET_FACEBOOK_URL', facebookUrl: string }
   | { type: 'PROFILE_SET_TWITTER_URL', twitterUrl: string }

--- a/react-app/src/utils/profile/profileReducer.ts
+++ b/react-app/src/utils/profile/profileReducer.ts
@@ -30,6 +30,8 @@ const profileReducer: Reducer<Profile, ProfileActions> = (prevProfile, action) =
       return { ...prevProfile, name: (action.name.length > 32 ? prevProfile.name : action.name) || undefined };
     case 'PROFILE_SET_BIO':
       return { ...prevProfile, bio: (action.bio.length > 160 ? prevProfile.bio : action.bio) || undefined };
+    case 'PROFILE_SET_IMAGE_URL':
+      return { ...prevProfile, imageUrl: action.imageUrl || undefined };
 
     case 'PROFILE_SET_FACEBOOK_URL':
       return { ...prevProfile, facebookUrl: action.facebookUrl || undefined };


### PR DESCRIPTION
We've decided to allow profile photos as long as they are hosted by the RIT Esport's CDN. 

With being able to link a member to a profile, we decided the hierarchy will be member image url > profile image url, this is so if the manager wishes to upload something else for the players they can, while the player's profile will be their own photo.