### PR TITLE
Member Fix

### DIFF
--- a/express-api/src/models/team/division/member/member.ts
+++ b/express-api/src/models/team/division/member/member.ts
@@ -3,7 +3,7 @@ import { Schema } from 'mongoose';
 
 import { ProfileJoi } from '../../../profile';
 
-export interface Member {
+interface Member {
   _id?: string;
 
   username: string;


### PR DESCRIPTION
Because we use virtuals we can't just `export const Member`, because we use the interface as the same name, I forgot to remove the export from the interface. 

Typescript is great but makes you ?